### PR TITLE
Add range-based alert rules and MQTT server

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -6,7 +6,8 @@ import (
 )
 
 type ServerConfig struct {
-	Port string `json:"port"`
+	Port     string `json:"port"`
+	MqttPort string `json:"mqttPort"`
 }
 
 type DatabaseConfig struct {
@@ -54,6 +55,10 @@ func loadConfiguration(path string) (*Config, error) {
 
 	if config.Server.Port == "" {
 		config.Server.Port = "3000"
+	}
+
+	if config.Server.MqttPort == "" {
+		config.Server.MqttPort = "1883"
 	}
 
 	return &config, nil

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"iot-platform/internal/api/http/handler"
 	"iot-platform/internal/api/http/middleware"
+	mqttserver "iot-platform/internal/api/mqtt"
 	"iot-platform/internal/api/notifier"
 	"iot-platform/internal/api/notifier/notifiers"
 	"iot-platform/internal/database/postgres"
@@ -59,6 +60,12 @@ func main() {
 			notifService.Dispatch(payload.Alert, payload.Rule)
 		}
 	}()
+
+	// start MQTT server for sensor data ingestion
+	mqttSrv := mqttserver.NewServer(":"+config.Server.MqttPort, sensorDataService)
+	if err := mqttSrv.ListenAndServe(); err != nil {
+		log.Fatalf("Failed to start MQTT server: %v", err)
+	}
 
 	deviceHandler := handler.NewDeviceHandler(*deviceService)
 	mux := http.NewServeMux()

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
     "db": "iot_platform"
   },
   "server": {
-    "port": "8080"
+    "port": "8080",
+    "mqttPort": "1883"
   }
 }

--- a/internal/api/mqtt/server.go
+++ b/internal/api/mqtt/server.go
@@ -1,0 +1,121 @@
+package mqtt
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"iot-platform/internal/model"
+	"iot-platform/internal/service"
+	"log"
+	"net"
+	"strings"
+	"time"
+)
+
+type Server struct {
+	addr              string
+	sensorDataService *service.SensorDataService
+}
+
+func NewServer(addr string, sensorDataService *service.SensorDataService) *Server {
+	return &Server{addr: addr, sensorDataService: sensorDataService}
+}
+
+func (s *Server) ListenAndServe() error {
+	ln, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+	log.Printf("MQTT server listening on %s", s.addr)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				log.Printf("accept error: %v", err)
+				continue
+			}
+			go s.handleConn(conn)
+		}
+	}()
+	return nil
+}
+
+func (s *Server) handleConn(conn net.Conn) {
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+	if err := s.handleConnect(r, conn); err != nil {
+		log.Printf("connect error: %v", err)
+		return
+	}
+	for {
+		if err := s.handlePublish(r); err != nil {
+			if err != io.EOF {
+				log.Printf("publish error: %v", err)
+			}
+			return
+		}
+	}
+}
+
+func (s *Server) handleConnect(r *bufio.Reader, conn net.Conn) error {
+	header, err := r.ReadByte()
+	if err != nil {
+		return err
+	}
+	if header>>4 != 1 {
+		return fmt.Errorf("expected CONNECT packet")
+	}
+	rl, err := r.ReadByte()
+	if err != nil {
+		return err
+	}
+	buf := make([]byte, int(rl))
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return err
+	}
+	_, err = conn.Write([]byte{0x20, 0x02, 0x00, 0x00})
+	return err
+}
+
+func (s *Server) handlePublish(r *bufio.Reader) error {
+	header, err := r.ReadByte()
+	if err != nil {
+		return err
+	}
+	if header>>4 != 3 {
+		return fmt.Errorf("expected PUBLISH packet")
+	}
+	rl, err := r.ReadByte()
+	if err != nil {
+		return err
+	}
+	buf := make([]byte, int(rl))
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return err
+	}
+	topicLen := int(buf[0])<<8 | int(buf[1])
+	topic := string(buf[2 : 2+topicLen])
+	payload := buf[2+topicLen:]
+	parts := strings.Split(topic, "/")
+	if len(parts) != 2 || parts[0] != "sensor-data" {
+		return nil
+	}
+	deviceID := parts[1]
+	var msg struct {
+		MetricName  string  `json:"metricName"`
+		MetricValue float64 `json:"metricValue"`
+	}
+	if err := json.Unmarshal(payload, &msg); err != nil {
+		return err
+	}
+	data := &model.SensorData{
+		DeviceId:    deviceID,
+		MetricName:  msg.MetricName,
+		MetricValue: msg.MetricValue,
+		Timestamp:   time.Now(),
+	}
+	ctx := context.Background()
+	return s.sensorDataService.CreateSensorData(ctx, data)
+}

--- a/internal/model/alertrule.go
+++ b/internal/model/alertrule.go
@@ -8,7 +8,9 @@ import (
 type RuleDefiniton struct {
 	MetricName      string  `json:"metricName"`
 	Condition       string  `json:"condition"`
-	MetricValue     float64 `json:"metricValue"`
+	MetricValue     float64 `json:"metricValue,omitempty"`
+	MetricValueMin  float64 `json:"metricValueMin,omitempty"`
+	MetricValueMax  float64 `json:"metricValueMax,omitempty"`
 	DurationMinutes int     `json:"durationMinutes"`
 }
 

--- a/internal/service/rule_evaluation_service.go
+++ b/internal/service/rule_evaluation_service.go
@@ -81,6 +81,8 @@ func (ru *RuleEvaluationService) Evaluate(ctx context.Context, data model.Sensor
 			isTriggered = data.MetricValue < def.MetricValue
 		case "eq":
 			isTriggered = data.MetricValue == def.MetricValue
+		case "between":
+			isTriggered = data.MetricValue >= def.MetricValueMin && data.MetricValue <= def.MetricValueMax
 		}
 
 		ru.mu.Lock()
@@ -106,8 +108,6 @@ func (ru *RuleEvaluationService) Evaluate(ctx context.Context, data model.Sensor
 				state.AlertSent = true
 				ru.stateCache[key] = state
 			}
-
-			ru.createTriggeredAlert(ctx, rule, data)
 		} else {
 			if isTracked {
 				log.Printf("condition for rule '%s' with device id '%s' has cleared, resetting.\n", rule.Name, data.DeviceId)


### PR DESCRIPTION
## Summary
- support between condition with min/max threshold fields in alert rule definitions
- evaluate between rules and trigger alerts only once after dwell duration
- introduce basic MQTT server for ingesting sensor data alongside HTTP API

## Testing
- `go vet ./...`
- `go test ./...` *(fails: argument mismatch in device repository tests)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac59e950a483238ffe4194e2cc9500